### PR TITLE
Added logic to create mag vector and pass it to nmag script

### DIFF
--- a/backend/nsim.py
+++ b/backend/nsim.py
@@ -1,6 +1,7 @@
 import nmag
 from nmag import SI
 import json
+import random
 
 class Vector3:
     def __init__(self, x, y, z):
@@ -25,7 +26,6 @@ Args:
     aabb (dict): The AABB dictionary with 'min' and 'max' keys.
 """
 def is_point_inside_aabb(point, aabb):
-
     x_min = aabb['min']['x']
     x_max = aabb['max']['x']
     y_min = aabb['min']['y']
@@ -34,9 +34,9 @@ def is_point_inside_aabb(point, aabb):
     z_max = aabb['max']['z']
     
     return (
-        point.x >= x_min and point.x <= x_max and
-        point.y >= y_min and point.y <= y_max and
-        point.z >= z_min and point.z <= z_max
+        point['x'] >= x_min and point['x'] <= x_max and
+        point['y'] >= y_min and point['y'] <= y_max and
+        point['z'] >= z_min and point['z'] <= z_max
     )
 
 """
@@ -85,10 +85,18 @@ with open("magnetization_fields.json", "r") as magnetization_fields_file:
     magnetization_fields = json.load(magnetization_fields_file)
 
 def set_initial_mag(point):
+    pointObj = {
+        "x": point[0],
+        "y": point[1],
+        "z": point[2],
+    }
     for magField in magnetization_fields:
-        if is_point_inside_mag_field(point, magField):
-            return [0,1,0] # TODO: calculate the magnetization vector based on polarity and position
-    return [0,0,0]
+        if is_point_inside_mag_field(pointObj, magField):
+            vector = magField["vector"]
+            return [vector.x, vector.y, vector.z]
+    # Set a random vector because a 0 vector ends up in a divide 
+    # by 0 error because the regions aren't proprerly tagged
+    return [random.random() for _ in range(3)]
 
 #create simulation object
 sim = nmag.Simulation()
@@ -104,7 +112,7 @@ sim.load_mesh("generated.nmesh.h5",
               unit_length = SI(1e-9, "m"))
 
 # set initial magnetisation
-sim.set_m([1,0,0])
+sim.set_m(set_initial_mag)
 
 # set external field
 sim.set_H_ext([0,0,0], SI("A/m"))

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,5 +1,7 @@
 # Magnetization Enum Schema
 # Represents the possible states of magnetization.
+# Positive means the magnetization is pointing outwards
+# from the arms. Negative means the opposite
 magnetization_enum_schema = {
     "type": "string",
     "enum": ["positive", "negative", "none"],
@@ -25,7 +27,25 @@ point_schema = {
     "description": "Represents a point in 3D space, with an optional exterior flag."
 }
 
-# AABB Interface Schema
+# Vector Interface Schema
+# @interface Vector
+# @property x - Width of the vector
+# @property y - Height of the vector
+# @property z - Length of the vector
+vector_schema = {
+    "type": "object",
+    "properties": {
+        "x": {"type": "number", "description": "Width of the vector."},
+        "y": {"type": "number", "description": "Height of the vector."},
+        "z": {"type": "number", "description": "Length of the vector."}
+    },
+    "required": ["x", "y", "z"],
+    "additionalProperties": False,
+    "description": "Represents a vector in 3D space."
+}
+
+
+# AABB Interface Schema (Bounds)
 # @interface Bounds
 # @property min - The minimum x, y, and z coordinates of the bounding box.
 # @property max - The maximum x, y, and z coordinates of the bounding box.
@@ -42,9 +62,10 @@ aabb_schema = {
 
 # MagnetizationField Interface Schema
 # @interface MagnetizationField
-# @property points -
-# Outer array of length 2 and inner arrays of length 4 to represent the bounds of the rectangular cuboid
+# @property points - Outer array of length 2 and inner arrays of length 4 to represent the bounds of the rectangular cuboid
+# @property aabb - Axis aligned bounding box
 # @property magnetization - Negative or positive magnetization
+# @property vector - the vector representing the direction of the magnetization field
 magnetization_field_schema = {
     "type": "object",
     "properties": {
@@ -54,16 +75,17 @@ magnetization_field_schema = {
             "items": {
                 "type": "array",
                 "items": point_schema,
-                "minItems": 4, # Assuming inner arrays are always length 4 based on typical cuboid representation
+                "minItems": 4,  # Assuming inner arrays are always length 4 based on typical cuboid representation
                 "maxItems": 4
             },
-            "minItems": 2, # Assuming outer array is always length 2 for min/max bounds or similar
+            "minItems": 2,  # Assuming outer array is always length 2 for min/max bounds or similar
             "maxItems": 2
         },
         "aabb": aabb_schema,
-        "magnetization": magnetization_enum_schema
+        "magnetization": magnetization_enum_schema,
+        "vector": vector_schema
     },
-    "required": ["points", "aabb", "magnetization"],
+    "required": ["points", "aabb", "magnetization", "vector"],
     "additionalProperties": False,
     "description": "Represents a field of magnetization within a defined set of points."
 }

--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -47,7 +47,7 @@ let tetrahedrons = []
 let magnetizationFields = [];
 
 const renderMesh = async () => {
-	const padding = { x: 0, y: 0.00001 };
+	const padding = { x: 0.01, y: 0.01 };
 	const componentModel = await (await fetch('res/triangle.json')).json()
 	const result = arrangeModel(positionGrid, magnetizationGrid, componentModel, padding)
 	tetrahedrons = result.tetrahedrons

--- a/frontend/js/modules/model-utils.js
+++ b/frontend/js/modules/model-utils.js
@@ -174,6 +174,40 @@ const calculateAABB = (points) => {
 }
 
 /**
+ * @param {Types['Magnetization']} magnetization
+ * @param {boolean} isEvenRow
+ * @param {"a" | "b" | "c"} armLetter
+ * @returns {Types['Vector']}
+ */
+const calculateVector = (magnetization, isEvenRow, armLetter) => {
+	// For the base vectors assume that arms are pointing outward
+	/** @type {Types['Vector']} */
+	const aBaseVector = { x: 0, y: 1, z:0 }
+	/** @type {Types['Vector']} */
+	const bBaseVector = { x: Math.sqrt(3)/2, y: -1/2, z:0 }
+	/** @type {Types['Vector']} */
+	const cBaseVector = { x: -Math.sqrt(3)/2, y: -1/2, z:0 }
+
+	/** @type {Types['Vector']} */
+	let vector;
+
+	if (armLetter === "a") {
+		vector = aBaseVector
+	} else if (armLetter === "b") {
+		vector = bBaseVector
+	} else if (armLetter === "c") {
+		vector = cBaseVector
+	} else {
+		throw Error(`Invalid arm letter passed in: ${armLetter}`)
+	}
+
+	if (magnetization === Magnetization.POSITIVE && isEvenRow || magnetization === Magnetization.NEGATIVE && !isEvenRow) {
+		return vector
+	}
+	return  {x: vector.x * -1, y: vector.y * -1, z: vector.z }
+}
+
+/**
  * Given a triangle magnetization points and offsets, calculates the magnetic field around each point. 
  * This will be a rectangular cuboid so it will contain 8 points and a magnetization.
  * @param {Types['TriangleMagnetization']} triangleMagnetization
@@ -236,6 +270,7 @@ const getMagnetizationFields = (triangleMagnetization, bounds, armBounds, isEven
 			magnetization: triangleMagnetization.a,
 			points,
 			aabb: calculateAABB(points),
+			vector: calculateVector(triangleMagnetization.a, isEvenRow, "a")
 		})
 	}
 	if (triangleMagnetization.b !== Magnetization.NONE) {
@@ -247,6 +282,7 @@ const getMagnetizationFields = (triangleMagnetization, bounds, armBounds, isEven
 			magnetization: triangleMagnetization.b,
 			points,
 			aabb: calculateAABB(points),
+			vector: calculateVector(triangleMagnetization.b, isEvenRow, "b"),
 		})
 	}
 	if (triangleMagnetization.c !== Magnetization.NONE) {
@@ -258,6 +294,7 @@ const getMagnetizationFields = (triangleMagnetization, bounds, armBounds, isEven
 			magnetization: triangleMagnetization.c,
 			points,
 			aabb: calculateAABB(points),
+			vector: calculateVector(triangleMagnetization.c, isEvenRow, "c"),
 		})
 	}
 	return magnetizationFields;

--- a/frontend/js/types.d.ts
+++ b/frontend/js/types.d.ts
@@ -1,5 +1,7 @@
 /**
  * Represents the possible states of magnetization.
+ * Positive means the magnetization is pointing outwards 
+ * from the arms. Negative means the opposite
  */
 enum Magnetization {
   POSITIVE = 'positive',
@@ -54,11 +56,13 @@ interface Vector {
  * Outer array of length 2 and inner arrays of length 4 to represent the bounds of the rectangular cuboid
  * @property aabb - Axis aligned bounding box
  * @property magnetization - Negative or positive magnetization
+ * @property vector - the vector representing the direction of the magnetization field
  */
 interface MagnetizationField {
   points: Array<Array<Point>>;
   aabb: AABB;
   magnetization: Magnetization;
+  vector: Vector;
 }
 
 interface Bounds {


### PR DESCRIPTION
* Updated nsim to use point dict/objects instead of tuples
* Return a random vector because of divide by 0 error because the regions aren't well defined
* Use set_initial_mag function
* Updated schema to take mag vector
* Update padding so fields don't overlap
* Calculated vector based on arm, position of triangle, and negative/positive magnetization
* Simulation now runs fine